### PR TITLE
Handle meta parameter as callback

### DIFF
--- a/lib/workflow-pg-backend.js
+++ b/lib/workflow-pg-backend.js
@@ -957,6 +957,10 @@ var WorkflowPgBackend = module.exports = function (config) {
         if (typeof (val) === 'object' && val !== null && prop !== 'params') {
             val = JSON.stringify(val);
         }
+        if (typeof (meta) === 'function') {
+            callback = meta;
+            meta = {};
+        }
 
         var vals = [val, uuid];
         _execQuery(query, vals, function (err, res) {


### PR DESCRIPTION
Just as the redis backend lib does (https://github.com/kusor/node-workflow-redis-backend/blob/master/lib/workflow-redis-backend.js#L843)

Might be needed in other functions as well.
