### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "node": ">=0.8"
   },
   "dependencies": {
-    "pg": "6.0.1",
     "bunyan": "0.23.1",
+    "pg": "6.0.1",
+    "uuid": "^3.0.0",
     "vasync": "1.3.3",
-    "node-uuid": "1.4.7",
     "wf": "~1.0.1"
   },
   "devDependencies": {

--- a/test/pg-backend.test.js
+++ b/test/pg-backend.test.js
@@ -8,7 +8,7 @@
 // or whatever the postgres user you want to run tests as.
 
 var test = require('tap').test;
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var SOCKET = '/tmp/.' + uuid();
 var util = require('util');
 var vasync = require('vasync');


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.